### PR TITLE
Set updated_in according to standard Magento

### DIFF
--- a/src/Observers/EeProductObserver.php
+++ b/src/Observers/EeProductObserver.php
@@ -78,7 +78,7 @@ class EeProductObserver extends ProductObserver
             $additionalAttr = array(
                 MemberNames::ENTITY_ID  => $this->nextIdentifier(),
                 MemberNames::CREATED_IN => 1,
-                MemberNames::UPDATED_IN => strtotime(SqlConstants::MAX_UNIXTIMESTAMP)
+                MemberNames::UPDATED_IN => SqlConstants::MAX_UNIXTIMESTAMP
             );
 
             // merge and return the attributes

--- a/src/Observers/EeProductObserver.php
+++ b/src/Observers/EeProductObserver.php
@@ -20,6 +20,7 @@
 
 namespace TechDivision\Import\Product\Ee\Observers;
 
+use TechDivision\Import\Ee\Utils\SqlConstants;
 use TechDivision\Import\Utils\EntityStatus;
 use TechDivision\Import\Product\Utils\ColumnKeys;
 use TechDivision\Import\Product\Ee\Utils\MemberNames;
@@ -77,7 +78,7 @@ class EeProductObserver extends ProductObserver
             $additionalAttr = array(
                 MemberNames::ENTITY_ID  => $this->nextIdentifier(),
                 MemberNames::CREATED_IN => 1,
-                MemberNames::UPDATED_IN => strtotime('+20 years')
+                MemberNames::UPDATED_IN => strtotime(SqlConstants::MAX_UNIXTIMESTAMP)
             );
 
             // merge and return the attributes


### PR DESCRIPTION
Currently Magento evaluates the timestamp in only in PHP context. This is a precaution to avoid unexpected behaviour shoud the timestamp sometime be evaluated in SQL.