### PR TITLE
Update default configuration for grouped product import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Version 7.0.1
+
+## Bugfixes
+
+* None
+
+## Features
+
+* Update default configuration for grouped product import
+* Refactor default configuration, replace the import_product_link.observer.link.update with import_product_link.observer.link for update operation
+
 # Version 7.0.0
 
 ## Bugfixes

--- a/etc/techdivision-import.json
+++ b/etc/techdivision-import.json
@@ -126,7 +126,8 @@
                     "import_product_variant.observer.product.variant",
                     "import_product_bundle.observer.product.bundle",
                     "import_product_media.observer.product.media",
-                    "import_product_link.observer.product.link"
+                    "import_product_link.observer.product.link",
+                    "import_product_grouped.observer.product.grouped"
                   ]
                 },
                 {
@@ -169,6 +170,19 @@
                     "import_product_bundle_ee.observer.bundle.selection",
                     "import_product_bundle.observer.bundle.selection.price",
                     "import_product_bundle_ee.observer.bundle.product.relation"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "import_product_grouped_ee.subject.grouped",
+              "file-resolver": {
+                "prefix": "grouped"
+              },
+              "observers": [
+                {
+                  "import": [
+                    "import_product_grouped_ee.observer.grouped.product.relation"
                   ]
                 }
               ]
@@ -278,7 +292,8 @@
                     "import_product_bundle.observer.product.bundle",
                     "import_product_media.observer.product.media",
                     "import_product_media.observer.clear.media.gallery",
-                    "import_product_link.observer.product.link"
+                    "import_product_link.observer.product.link",
+                    "import_product_grouped.observer.product.grouped"
                   ]
                 },
                 {
@@ -326,6 +341,19 @@
               ]
             },
             {
+              "id": "import_product_grouped_ee.subject.grouped",
+              "file-resolver": {
+                "prefix": "grouped"
+              },
+              "observers": [
+                {
+                  "import": [
+                    "import_product_grouped_ee.observer.grouped.product.relation.update"
+                  ]
+                }
+              ]
+            },
+            {
               "id": "import_product_media_ee.subject.media",
               "file-resolver": {
                 "prefix": "media"
@@ -350,7 +378,7 @@
               "observers": [
                 {
                   "import": [
-                    "import_product_link_ee.observer.link.update",
+                    "import_product_link_ee.observer.link",
                     "import_product_link.observer.link.attribute.position.update"
                   ]
                 }


### PR DESCRIPTION
Refactor default configuration, replace the import_product_link.observer.link.update with import_product_link.observer.link for update operation