### PR TITLE
Add cleanup functionality on product link to remove product relations

### DIFF
--- a/etc/configuration/operations.json
+++ b/etc/configuration/operations.json
@@ -310,6 +310,7 @@
                     "media-directory" : "pub/media/catalog/product",
                     "images-file-directory" : "var/importexport/media/catalog/product",
                     "clean-up-variants": false,
+                    "clean-up-links": false,
                     "clean-up-media-gallery": true,
                     "clean-up-empty-image-columns": true,
                     "clean-up-website-product-relations": true,

--- a/symfony/Resources/config/2.3.2/services.xml
+++ b/symfony/Resources/config/2.3.2/services.xml
@@ -166,6 +166,9 @@
                 <argument id="import_product_link.observer.product.link" type="service"/>
             </call>
             <call method="addObserver">
+                <argument id="import_product_link_ee.observer.clean.up.product.link" type="service"/>
+            </call>
+            <call method="addObserver">
                 <argument id="import_product_grouped.observer.product.grouped" type="service"/>
             </call>
             <call method="addObserver">

--- a/symfony/Resources/config/services.xml
+++ b/symfony/Resources/config/services.xml
@@ -283,6 +283,9 @@
                 <argument id="import_product_link.observer.product.link" type="service"/>
             </call>
             <call method="addObserver">
+                <argument id="import_product_link_ee.observer.clean.up.product.link" type="service"/>
+            </call>
+            <call method="addObserver">
                 <argument id="import_product_grouped.observer.product.grouped" type="service"/>
             </call>
             <call method="addObserver">


### PR DESCRIPTION
In operation.json you can define Add-Update parameters `'clean-up-links': true,`. The default value is `false`.

To delete a complete link, enter the value `__REMOVE__RELATION__` as SKU in the columns "upsell_skus", "crosssell_skus" or "related_skus".

An empty value ignores the columns.